### PR TITLE
Added support for delete

### DIFF
--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -185,6 +185,10 @@ class BaseS3Uploader(object):
 
         return url
 
+    def get_file_size(self, filepath):
+        s3 = self.get_s3_resource();
+        return s3.Object(self.bucket_name, filepath).content_length
+
 
 class S3Uploader(BaseS3Uploader):
     '''
@@ -401,3 +405,7 @@ class S3ResourceUploader(BaseS3Uploader):
             log.warning('Key {0} not found in bucket {1} for delete'
                         .format(key_path, self.bucket_name))
             pass
+
+    def find_file_size(self, filename):
+        return self.get_file_size(filepath=filename)
+

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -71,7 +71,7 @@ class BaseS3Uploader(object):
 
     def get_s3_resource(self):
         return \
-            self.get_s3_session()\
+            self.get_s3_session() \
                 .resource('s3',
                           endpoint_url=self.host_name,
                           config=BotoConfig(
@@ -80,7 +80,7 @@ class BaseS3Uploader(object):
 
     def get_s3_client(self):
         return \
-            self.get_s3_session()\
+            self.get_s3_session() \
                 .client('s3',
                         endpoint_url=self.host_name,
                         config=BotoConfig(
@@ -124,27 +124,23 @@ class BaseS3Uploader(object):
         return bucket
 
     def upload_to_key(self, filepath, upload_file, make_public=False):
-        '''Uploads the `upload_file` to `filepath` on `self.bucket`.'''
+        """Uploads the `upload_file` to `filepath` on `self.bucket`."""
 
         upload_file.seek(0)
 
         s3 = self.get_s3_resource()
-        config = TransferConfig(multipart_threshold=1024 * 25,
-                                max_concurrency= 10,
-                                multipart_chunksize= 1024 * 25,
-                                use_threads= True)
+        transfer_config = TransferConfig(multipart_threshold=1024 * 25,
+                                         max_concurrency=10,
+                                         multipart_chunksize=1024 * 25,
+                                         use_threads=True)
         try:
-            s3.Object(self.bucket_name, filepath).\
-                upload_file(upload_file.read(),
-                              ExtraArgs={
-                                  'ACL':'public-read' if make_public else self.acl,
-                                  'ContentType': getattr(self, 'mimetype', '') or 'text/plain'
-                              },
-                              Config=config)
-            # s3.Object(self.bucket_name, filepath).put(
-            #     Body=upload_file.read(),
-            #     ACL='public-read' if make_public else self.acl,
-            #     ContentType=getattr(self, 'mimetype', '') or 'text/plain')
+            s3.Object(self.bucket_name, filepath). \
+                upload_fileobj(upload_file,
+                               ExtraArgs={
+                                   'ACL': 'public-read' if make_public else self.acl,
+                                   'ContentType': getattr(self, 'mimetype', '') or 'text/plain'
+                               },
+                               Config=transfer_config)
             log.info("Successfully uploaded {0} to S3!".format(filepath))
         except Exception as e:
             log.error('Something went very very wrong for {0}'.format(str(e)))
@@ -152,7 +148,7 @@ class BaseS3Uploader(object):
 
     def clear_key(self, filepath):
         '''Deletes the contents of the key at `filepath` on `self.bucket`.'''
-
+        log.info('From s3 delete file with path : {0}'.format(filepath))
         s3 = self.get_s3_resource()
 
         try:
@@ -307,7 +303,6 @@ class S3ResourceUploader(BaseS3Uploader):
         self.storage_path = os.path.join(path, 'resources')
         self.filename = None
         self.old_filename = None
-
         upload_field_storage = resource.pop('upload', None)
         self.clear = resource.pop('clear_upload', None)
 
@@ -333,7 +328,7 @@ class S3ResourceUploader(BaseS3Uploader):
             self.filesize = self.upload_file.tell()
             # go back to the beginning of the file buffer
             self.upload_file.seek(0, os.SEEK_SET)
-
+            log.debug('The uploaded file size: {0}'.format(self.filesize))
             self.mimetype = resource.get('mimetype')
             if not self.mimetype:
                 try:
@@ -355,10 +350,10 @@ class S3ResourceUploader(BaseS3Uploader):
 
                 except Exception:
                     pass
-
         elif self.clear and resource.get('id'):
             # New, not yet created resources can be marked for deletion if the
             # users cancels an upload and enters a URL instead.
+            # This will also be called on resource_delete
             old_resource = model.Session.query(model.Resource) \
                 .get(resource['id'])
             self.old_filename = old_resource.url
@@ -379,7 +374,6 @@ class S3ResourceUploader(BaseS3Uploader):
 
     def upload(self, id, max_size=10):
         '''Upload the file to S3.'''
-
         # If a filename has been provided (a file is being uploaded) write the
         # file to the appropriate key in the AWS bucket.
         if self.filename:
@@ -397,7 +391,6 @@ class S3ResourceUploader(BaseS3Uploader):
 
     def delete(self, id, filename=None):
         ''' Delete file we are pointing at'''
-
         if filename is None:
             filename = os.path.basename(self.url)
         filename = munge.munge_filename(filename)

--- a/ckanext/s3filestore/views/resource.py
+++ b/ckanext/s3filestore/views/resource.py
@@ -26,11 +26,12 @@ get_action = logic.get_action
 abort = base.abort
 redirect = toolkit.redirect_to
 
+log.debug('Inside the resource.py view')
 
 s3_resource = Blueprint(
     u's3_resource',
     __name__,
-    url_prefix=u'/dataset/<id>/resource',
+    url_prefix=u'/data/dataset/<id>/resource',
     url_defaults={u'package_type': u'dataset'}
 )
 
@@ -70,7 +71,7 @@ def resource_download(package_type, id, resource_id, filename=None):
                 url = upload.get_signed_url_to_key(key_path)
             else:
                 file_size = upload.find_file_size(filename=key_path)
-                log.debug('Content-Length: {0}'.format(file_size))
+                log.debug('Content-Length1: {0}'.format(file_size))
                 # If a file size is greater than 10MB it should then automatically download the file
                 # instead of allowing users to view the file inside the browser
                 if file_size >= 10485760:

--- a/ckanext/s3filestore/views/resource.py
+++ b/ckanext/s3filestore/views/resource.py
@@ -69,11 +69,19 @@ def resource_download(package_type, id, resource_id, filename=None):
             if preview:
                 url = upload.get_signed_url_to_key(key_path)
             else:
-                params = {
-                    'ResponseContentDisposition':
-                        'attachment; filename=' + filename,
-                }
-                url = upload.get_signed_url_to_key(key_path, params)
+                file_size = upload.find_file_size(filename=key_path)
+                log.debug('Content-Length: {0}'.format(file_size))
+                # If a file size is greater than 10MB it should then automatically download the file
+                # instead of allowing users to view the file inside the browser
+                if file_size >= 10485760:
+                    params = {
+                        'ResponseContentDisposition':
+                            'attachment; filename=' + filename,
+                    }
+                    url = upload.get_signed_url_to_key(key_path, params)
+                else:
+                    url = upload.get_signed_url_to_key(key_path)
+
             return redirect(url)
 
         except ClientError as ex:

--- a/ckanext/s3filestore/views/uploads.py
+++ b/ckanext/s3filestore/views/uploads.py
@@ -25,7 +25,6 @@ s3_uploads = Blueprint(
 
 def uploaded_file_redirect(upload_to, filename):
     '''Redirect static file requests to their location on S3.'''
-
     storage_path = S3Uploader.get_storage_path(upload_to)
     filepath = os.path.join(storage_path, filename)
     base_uploader = BaseS3Uploader()


### PR DESCRIPTION
With the plugin the features added were
1. Support for multipart uploads
2. Support to delete resource from S3 after the resource from removed from CKAN

**Fix Details:**

For multipart uploads simply used boto3 with ```boto3.resource('s3').upload_fileobj()``` this method support of sending a binary object to S3 and split the file into chunks of 25MB. 
Created the `TransferConfiguration` object to support multiple threads to support faster uploads as such it will spin off 10 threads

Implemented an additional Interface ```IResourceController``` which allows to capture the click on the delete button.
this allows the capture the resource that is requested to being removed after this we pass the resource to the uploader.upload with the setting of `("clear_upload", True)` and this then allows for the file to be removed from S3.